### PR TITLE
Added 'initial interval' to emitter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 /.idea/
 /bin/
+/out/
+
+tonegodemitter.iml
+**/.directory

--- a/src/tonegod/emitter/messages/messages.properties
+++ b/src/tonegod/emitter/messages/messages.properties
@@ -1,0 +1,89 @@
+Interpolation.Linear=Linear
+Interpolation.Fade=Fade
+Interpolation.Sine=Sine
+Interpolation.SineIn=Sine In
+Interpolation.SineOut=Sine Out
+Interpolation.Exp10=Exp 10
+Interpolation.ExpIn10=Exp In 10
+Interpolation.ExpOut10=Exp Out 10
+Interpolation.Exp5=Exp 5
+Interpolation.ExpIn5=Exp In 5
+Interpolation.ExpOut5=Exp Out 5
+Interpolation.Circle=Circle
+Interpolation.CircleIn=Circle In
+Interpolation.CircleOut=Circle Out
+Interpolation.Swing=Swing
+Interpolation.SwingIn=Swing In
+Interpolation.SwingOut=Swing Out
+Interpolation.Bounce=Bounce
+Interpolation.BounceIn=Bounce In
+Interpolation.BounceOut=Bounce Out
+Interpolation.Pow2=Pow 2
+Interpolation.PowIn2=Pow In 2
+Interpolation.PowOut2=Pow Out 2
+Interpolation.Pow3=Pow 3
+Interpolation.PowIn3=Pow In 3
+Interpolation.PowOut3=Pow Out 3
+Interpolation.Pow4=Pow 4
+Interpolation.PowIn4=Pow In 4
+Interpolation.PowOut4=Pow Out 4
+Interpolation.Pow5=Pow 5
+Interpolation.PowIn5=Pow In 5
+Interpolation.PowOut5=Pow Out 5
+Interpolation.Elastic=Elastic
+Interpolation.ElasticIn=Elastic In
+Interpolation.ElasticOut=Elastic Out
+
+Emission.Point.Center=Center
+Emission.Point.EdgeTop=Edge top
+Emission.Point.EdgeBottom=Edge bottom
+
+EmitterMesh.DirectionType.Normal=Normal
+EmitterMesh.DirectionType.NormalNegate=Normal negate
+EmitterMesh.DirectionType.Random=Random
+EmitterMesh.DirectionType.RandomTangent=Random tangent
+EmitterMesh.DirectionType.RandomNormalAligned=Random normal aligned
+EmitterMesh.DirectionType.RandomNormalNegate=Random normal negate
+
+BillboardMode.Velocity=Velocity
+BillboardMode.VelocityZUp=Velocity Z up
+BillboardMode.VelocityZUpYLeft=Velocity Z up Y left
+BillboardMode.Normal=Normal
+BillboardMode.NormalYUp=Normal Y up
+BillboardMode.Camera=Camera
+BillboardMode.UnitX=X direction
+BillboardMode.UnitY=Y direction
+BillboardMode.UnitZ=Z direction
+
+ParticleInfluencer.Alpha=Alpha gradient
+ParticleInfluencer.Color=Color gradient
+ParticleInfluencer.Destination=Destination path
+ParticleInfluencer.Gravity=Gravity
+ParticleInfluencer.Impulse=Impulse
+ParticleInfluencer.Physics=Physics collision
+ParticleInfluencer.RadialVelocity=Radial rotation
+ParticleInfluencer.Rotation=Rotation
+ParticleInfluencer.Size=Size gradient
+ParticleInfluencer.Sprite=Sprite animation
+
+ParticleInfluencer.Gravity.Alignment.World=World
+ParticleInfluencer.Gravity.Alignment.ReverseVelocity=Reverse velocity
+ParticleInfluencer.Gravity.Alignment.EmissionPoint=Emission point
+ParticleInfluencer.Gravity.Alignment.EmitterCenter=Emitter center
+
+ParticleInfluencer.Physics.CollisionReaction.Bounce=Bounce
+ParticleInfluencer.Physics.CollisionReaction.Stick=Stick
+ParticleInfluencer.Physics.CollisionReaction.Destroy=Destroy
+
+ParticleInfluencer.RadialVelocity.PullAlignment.EmissionPoint=Emission point
+ParticleInfluencer.RadialVelocity.PullAlignment.EmitterCenter=Emitter center
+
+ParticleInfluencer.RadialVelocity.PullCenter.Absolute=Absolute
+ParticleInfluencer.RadialVelocity.PullCenter.X=X-axis
+ParticleInfluencer.RadialVelocity.PullCenter.Y=Y-axis
+ParticleInfluencer.RadialVelocity.PullCenter.Z=Z-axis
+
+ParticleInfluencer.RadialVelocity.UpAlignment.Normal=Normal
+ParticleInfluencer.RadialVelocity.UpAlignment.UnitX=X direction
+ParticleInfluencer.RadialVelocity.UpAlignment.UnitY=Y direction
+ParticleInfluencer.RadialVelocity.UpAlignment.UnitZ=Z direction


### PR DESCRIPTION
Currently, when resetting the interval it starts from 0, meaning that if the particles are emitted each second it will wait to that first second the first time. There isn't a way to start immediately the emission but remain the interval.
The new addition fixes that allowing to set an initial interval (to which the emitter will start each time it is reset)