### PR TITLE
Fixed deepClone not cloning material and particleDataMesh

### DIFF
--- a/src/main/java/tonegod/emitter/ParticleEmitterNode.java
+++ b/src/main/java/tonegod/emitter/ParticleEmitterNode.java
@@ -2182,6 +2182,18 @@ public class ParticleEmitterNode extends Node implements JmeCloneable, Cloneable
 
         particleTestGeometry = cloner.clone(particleTestGeometry);
         particleTestNode = cloner.clone(particleTestNode);
+        
+        if(particleGeometry.getMaterial() != null) {
+            material = particleGeometry.getMaterial();
+        } else {
+            material = cloner.clone(material);
+        }
+
+        if(particleGeometry.getMesh() != null) {
+            particleDataMesh = (ParticleDataMesh) particleGeometry.getMesh();
+        } else {
+            particleDataMesh = cloner.clone(particleDataMesh);
+        }
     }
 
     @Override


### PR DESCRIPTION
When deepCloning the particleDataMesh is cloned right for particleGeometry but it is overrided after by the not-cloned particleDataMesh. The material wasn't being cloned neither.
This was leading to issues like colors being the same after modifying an influencer for every deep cloned particle.