### PR TITLE
Added 'initial interval' to emitter

### DIFF
--- a/src/main/java/tonegod/emitter/ParticleEmitterNode.java
+++ b/src/main/java/tonegod/emitter/ParticleEmitterNode.java
@@ -101,9 +101,9 @@ public class ParticleEmitterNode extends Node implements JmeCloneable, Cloneable
     protected float currentInterval;
     
     /**
-     * The initial interval (value to set the currentInterval each time it is reset).
+     * If the interval must be start-aligned (the first emission is when the emitter is started)
      */
-    protected float initialInterval;
+    protected boolean startAlignedInterval;
 
     /**
      * The life of emitter.
@@ -456,7 +456,7 @@ public class ParticleEmitterNode extends Node implements JmeCloneable, Cloneable
         this.textureParamName = "Texture";
         this.inverseRotation = Matrix3f.IDENTITY.clone();
         this.targetInterval = 0.00015f;
-        this.initialInterval = 0;
+        this.startAlignedInterval = false;
         resetInterval();
         this.velocityStretchFactor = 0.35f;
         this.stretchAxis = ForcedStretchAxis.Y;
@@ -620,19 +620,20 @@ public class ParticleEmitterNode extends Node implements JmeCloneable, Cloneable
     }
 
     /**
-     * Gets the initial interval.
+     * Gets if the emission interval is start-aligned ((the first emission is when the emitter is started).
      *
-     * @return the initial interval.
+     * @return if the emission interval is start-aligned.
      */
-    protected float getInitialInterval() {
-        return initialInterval;
+    protected boolean isStartAlignedInterval() {
+        return startAlignedInterval;
     }
     
     /**
-     * @param initialInterval the initial interval eg: if a particle is to emmit every 1 second and this is set to 1 it will first spawn without any delay).
+     * @param startAlignedInterval if the emission interval is start-aligned
+     * (eg: if a particle is set to emmit every 1 second, with 0 delay and this is set to true it will first spawn without any delay).
      */
-    public void setInitialInterval(float initialInterval) {
-        this.initialInterval = initialInterval;
+    public void setStartAlignedInterval(boolean startAlignedInterval) {
+        this.startAlignedInterval = startAlignedInterval;
 
         if(emittedTime == 0) {
             resetInterval();
@@ -907,6 +908,11 @@ public class ParticleEmitterNode extends Node implements JmeCloneable, Cloneable
 
         this.emissionsPerSecond = emissionsPerSecond;
         targetInterval = 1f / emissionsPerSecond;
+        
+        if(emittedTime == 0) {
+            resetInterval();
+        }
+        
         requiresUpdate = true;
     }
 
@@ -2018,7 +2024,7 @@ public class ParticleEmitterNode extends Node implements JmeCloneable, Cloneable
      * Resets the current emission interval
      */
     public void resetInterval() {
-        currentInterval = initialInterval;
+        currentInterval = startAlignedInterval ? targetInterval : 0;
     }
 
     /**
@@ -2092,7 +2098,7 @@ public class ParticleEmitterNode extends Node implements JmeCloneable, Cloneable
         capsule.write(directionType.ordinal(), "directionType", 0);
         capsule.write(emitterLife, "emitterLife", 0);
         capsule.write(emitterDelay, "emitterDelay", 0);
-        capsule.write(initialInterval, "initialInterval", 0);
+        capsule.write(startAlignedInterval, "startAlignedInterval", false);
 
         // PARTICLES
         capsule.write(billboardMode.ordinal(), "billboardMode", 0);
@@ -2170,7 +2176,7 @@ public class ParticleEmitterNode extends Node implements JmeCloneable, Cloneable
         setDirectionType(DirectionType.valueOf(capsule.readInt("directionType", DirectionType.NORMAL.ordinal())));
         setEmitterLife(capsule.readFloat("emitterLife", 0F));
         setEmitterDelay(capsule.readFloat("emitterDelay", 0F));
-        setInitialInterval(capsule.readFloat("initialInterval", 0F));
+        setStartAlignedInterval(capsule.readFloat("startAlignedInterval", false));
 
         // PARTICLES
         setBillboardMode(BillboardMode.valueOf(capsule.readInt("billboardMode", BillboardMode.CAMERA.ordinal())));

--- a/src/main/java/tonegod/emitter/ParticleEmitterNode.java
+++ b/src/main/java/tonegod/emitter/ParticleEmitterNode.java
@@ -2176,7 +2176,7 @@ public class ParticleEmitterNode extends Node implements JmeCloneable, Cloneable
         setDirectionType(DirectionType.valueOf(capsule.readInt("directionType", DirectionType.NORMAL.ordinal())));
         setEmitterLife(capsule.readFloat("emitterLife", 0F));
         setEmitterDelay(capsule.readFloat("emitterDelay", 0F));
-        setStartAlignedInterval(capsule.readFloat("startAlignedInterval", false));
+        setStartAlignedInterval(capsule.readBoolean("startAlignedInterval", false));
 
         // PARTICLES
         setBillboardMode(BillboardMode.valueOf(capsule.readInt("billboardMode", BillboardMode.CAMERA.ordinal())));

--- a/src/main/java/tonegod/emitter/ParticleEmitterNode.java
+++ b/src/main/java/tonegod/emitter/ParticleEmitterNode.java
@@ -99,6 +99,11 @@ public class ParticleEmitterNode extends Node implements JmeCloneable, Cloneable
      * The current interval.
      */
     protected float currentInterval;
+    
+    /**
+     * The initial interval (value to set the currentInterval each time it is reset).
+     */
+    protected float initialInterval;
 
     /**
      * The life of emitter.
@@ -451,7 +456,8 @@ public class ParticleEmitterNode extends Node implements JmeCloneable, Cloneable
         this.textureParamName = "Texture";
         this.inverseRotation = Matrix3f.IDENTITY.clone();
         this.targetInterval = 0.00015f;
-        this.currentInterval = 0;
+        this.initialInterval = 0;
+        resetInterval();
         this.velocityStretchFactor = 0.35f;
         this.stretchAxis = ForcedStretchAxis.Y;
         this.emissionPoint = EmissionPoint.CENTER;
@@ -613,6 +619,28 @@ public class ParticleEmitterNode extends Node implements JmeCloneable, Cloneable
         return emittedTime;
     }
 
+    /**
+     * Gets the initial interval.
+     *
+     * @return the initial interval.
+     */
+    protected float getInitialInterval() {
+        return initialInterval;
+    }
+    
+    /**
+     * @param initialInterval the initial interval eg: if a particle is to emmit every 1 second and this is set to 1 it will first spawn without any delay).
+     */
+    public void setInitialInterval(float initialInterval) {
+        this.initialInterval = initialInterval;
+
+        if(emittedTime == 0) {
+            resetInterval();
+        }
+    }
+    
+    
+    
     @Override
     protected void setParent(@Nullable final Node parent) {
         super.setParent(parent);
@@ -1833,7 +1861,7 @@ public class ParticleEmitterNode extends Node implements JmeCloneable, Cloneable
         final boolean enabled = isEnabled();
 
         if (!enabled) {
-            currentInterval = 0;
+            resetInterval();
             return;
         } else if (!isEmitterInitialized() && !initialize()) {
             return;
@@ -1981,7 +2009,7 @@ public class ParticleEmitterNode extends Node implements JmeCloneable, Cloneable
      */
     public void reset() {
         killAllParticles();
-        currentInterval = 0;
+        resetInterval();
         emittedTime = 0;
         requiresUpdate = true;
     }
@@ -1990,7 +2018,7 @@ public class ParticleEmitterNode extends Node implements JmeCloneable, Cloneable
      * Resets the current emission interval
      */
     public void resetInterval() {
-        currentInterval = 0;
+        currentInterval = initialInterval;
     }
 
     /**
@@ -2064,6 +2092,7 @@ public class ParticleEmitterNode extends Node implements JmeCloneable, Cloneable
         capsule.write(directionType.ordinal(), "directionType", 0);
         capsule.write(emitterLife, "emitterLife", 0);
         capsule.write(emitterDelay, "emitterDelay", 0);
+        capsule.write(initialInterval, "initialInterval", 0);
 
         // PARTICLES
         capsule.write(billboardMode.ordinal(), "billboardMode", 0);
@@ -2141,6 +2170,7 @@ public class ParticleEmitterNode extends Node implements JmeCloneable, Cloneable
         setDirectionType(DirectionType.valueOf(capsule.readInt("directionType", DirectionType.NORMAL.ordinal())));
         setEmitterLife(capsule.readFloat("emitterLife", 0F));
         setEmitterDelay(capsule.readFloat("emitterDelay", 0F));
+        setInitialInterval(capsule.readFloat("initialInterval", 0F));
 
         // PARTICLES
         setBillboardMode(BillboardMode.valueOf(capsule.readInt("billboardMode", BillboardMode.CAMERA.ordinal())));

--- a/src/main/java/tonegod/emitter/ParticleEmitterNode.java
+++ b/src/main/java/tonegod/emitter/ParticleEmitterNode.java
@@ -2026,6 +2026,16 @@ public class ParticleEmitterNode extends Node implements JmeCloneable, Cloneable
     public void resetInterval() {
         currentInterval = startAlignedInterval ? targetInterval : 0;
     }
+    
+    /**
+     * Gets if the emitter is alive (it is still emitting particles) or if it has already ended (reached it max life)
+     *
+     * @return if the emitter is currently alive
+     */
+    public boolean isAlive() {
+        return emitterLife == 0F || emittedTime < emitterLife;
+    }
+    
 
     /**
      * This method should not be called.  Particles call this method to help track the next available particle index


### PR DESCRIPTION
Currently, when resetting the interval it starts from 0, meaning that if the particles are emitted each second it will wait to that first second the first time. There isn't a way to start immediately the emission but remain the interval.
The new addition fixes that allowing to set an initial interval (to which the emitter will start each time it is reset)

**PD**: (Already [pr'ed some time ago](https://github.com/JavaSaBr/tonegodemitter/pull/1) but it seems you forgot to apply this part when you implemented the changes separately)